### PR TITLE
Rich Text Component

### DIFF
--- a/.changeset/floppy-aliens-call.md
+++ b/.changeset/floppy-aliens-call.md
@@ -1,0 +1,5 @@
+---
+"@dictu/rich-text": major
+---
+
+add rich-text component

--- a/.changeset/old-squids-raise.md
+++ b/.changeset/old-squids-raise.md
@@ -1,0 +1,7 @@
+---
+"@dictu/paragraph": patch
+"@dictu/heading": patch
+"@dictu/link": patch
+---
+
+add sass mixins

--- a/.changeset/proud-aliens-roll.md
+++ b/.changeset/proud-aliens-roll.md
@@ -1,0 +1,5 @@
+---
+"@dictu/design-tokens": patch
+---
+
+set selector to ".dictu-theme" for component tokens

--- a/components/heading/src/_mixin.scss
+++ b/components/heading/src/_mixin.scss
@@ -1,0 +1,36 @@
+@use "pkg:@nl-design-system-candidate/heading-css/src/mixin" as nl-heading;
+
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021-2025 dictu
+ */
+
+@mixin dictu-heading {
+  @include nl-heading.nl-heading;
+
+  max-inline-size: var(--govnl-heading-max-inline-size);
+}
+
+@mixin dictu-heading--level-1 {
+  @include nl-heading.nl-heading--level-1;
+}
+
+@mixin dictu-heading--level-2 {
+  @include nl-heading.nl-heading--level-2;
+}
+
+@mixin dictu-heading--level-3 {
+  @include nl-heading.nl-heading--level-3;
+}
+
+@mixin dictu-heading--level-4 {
+  @include nl-heading.nl-heading--level-4;
+}
+
+@mixin dictu-heading--level-5 {
+  @include nl-heading.nl-heading--level-5;
+}
+
+@mixin dictu-heading--level-6 {
+  @include nl-heading.nl-heading--level-6;
+}

--- a/components/heading/src/index.scss
+++ b/components/heading/src/index.scss
@@ -1,29 +1,29 @@
-@use "pkg:@nl-design-system-candidate/heading-css/src/mixin" as mixin;
+@use "mixin" as mixin;
 
 .dictu-heading {
-  @include mixin.nl-heading;
+  @include mixin.dictu-heading;
 }
 
 .dictu-heading--level-1 {
-  @include mixin.nl-heading--level-1;
+  @include mixin.dictu-heading--level-1;
 }
 
 .dictu-heading--level-2 {
-  @include mixin.nl-heading--level-2;
+  @include mixin.dictu-heading--level-2;
 }
 
 .dictu-heading--level-3 {
-  @include mixin.nl-heading--level-3;
+  @include mixin.dictu-heading--level-3;
 }
 
 .dictu-heading--level-4 {
-  @include mixin.nl-heading--level-4;
+  @include mixin.dictu-heading--level-4;
 }
 
 .dictu-heading--level-5 {
-  @include mixin.nl-heading--level-5;
+  @include mixin.dictu-heading--level-5;
 }
 
 .dictu-heading--level-6 {
-  @include mixin.nl-heading--level-6;
+  @include mixin.dictu-heading--level-6;
 }

--- a/components/link/src/_mixin.scss
+++ b/components/link/src/_mixin.scss
@@ -1,0 +1,17 @@
+@use "pkg:@nl-design-system-candidate/link-css/src/mixin" as mixin;
+
+@mixin dictu-link {
+  @include mixin.nl-link;
+}
+
+@mixin dictu-link--hover {
+  @include mixin.nl-link--hover;
+}
+
+@mixin dictu-link--active {
+  @include mixin.nl-link--active;
+}
+
+@mixin dictu-link--inline-box {
+  @include mixin.nl-link--inline-box;
+}

--- a/components/link/src/index.scss
+++ b/components/link/src/index.scss
@@ -1,17 +1,17 @@
-@use "pkg:@nl-design-system-candidate/link-css/src/mixin" as mixin;
+@use "mixin" as mixin;
 
 .dictu-link {
-  @include mixin.nl-link;
+  @include mixin.dictu-link;
 }
 
 .dictu-link:hover {
-  @include mixin.nl-link--hover;
+  @include mixin.dictu-link--hover;
 }
 
 .dictu-link:active {
-  @include mixin.nl-link--active;
+  @include mixin.dictu-link--active;
 }
 
 .dictu-link--inline-box {
-  @include mixin.nl-link--inline-box;
+  @include mixin.dictu-link--inline-box;
 }

--- a/components/paragraph/src/_mixin.scss
+++ b/components/paragraph/src/_mixin.scss
@@ -1,0 +1,9 @@
+@use "pkg:@nl-design-system-candidate/paragraph-css/src/mixin" as mixin;
+
+@mixin dictu-paragraph {
+  @include mixin.nl-paragraph;
+}
+
+@mixin dictu-paragraph--lead {
+  @include mixin.nl-paragraph--lead;
+}

--- a/components/paragraph/src/index.scss
+++ b/components/paragraph/src/index.scss
@@ -1,9 +1,9 @@
-@use "pkg:@nl-design-system-candidate/paragraph-css/src/mixin" as mixin;
+@use "mixin" as mixin;
 
 .dictu-paragraph {
-  @include mixin.nl-paragraph;
+  @include mixin.dictu-paragraph;
 }
 
 .dictu-paragraph--lead {
-  @include mixin.nl-paragraph--lead;
+  @include mixin.dictu-paragraph--lead;
 }

--- a/components/rich-text/README.md
+++ b/components/rich-text/README.md
@@ -1,0 +1,46 @@
+<!-- @license CC0-1.0 -->
+
+De Rich Text component voegt standaard styling toe aan platte HTML waar je geen
+controle over hebt, zoals content uit een CMS.
+
+De volgende HTML elementen worden voorzien van standaard opmaak:
+
+- Paragrafen
+- Links
+- Kopteksten
+
+## Gebruik deze component
+
+Je kunt de CSS zo in je project installeren:
+
+```console
+npm install --save-dev @dictu/rich-text
+```
+
+Je kunt de CSS uit `node_modules/` importeren:
+
+```html
+<link rel="stylesheet" href="node_modules/@dictu/rich-text/dist/index.css" />
+```
+
+Als je CSS imports gebruikt vanuit JavaScript:
+
+```javascript
+import "@dictu/rich-text/index.css";
+```
+
+Dit component maakt gebruik van de design tokens van `@dictu/paragraph`,
+`@dictu/link` en `@dictu/heading`. Zorg ervoor dat je de design tokens van deze
+componenten ook hebt ingeladen als je dit component gebruikt.
+
+## Richtlijnen
+
+- Zorg ervoor dat de content van de component alleen `p`, `a`, en `h1` t/m `h6`
+  elementen bevat.
+- Zorg ervoor dat de semantische structuur van de tekst behouden blijft.
+- Voeg geen inline stijlen toe; vertrouw op de meegeleverde CSS voor consistente
+  opmaak.
+
+## Links
+
+- [Rich Text Content](https://www.nldesignsystem.nl/rich-text-content/)

--- a/components/rich-text/docs/_rich-text.md
+++ b/components/rich-text/docs/_rich-text.md
@@ -1,0 +1,3 @@
+<!-- @license CC0-1.0 -->
+
+Gebruik in CSS de `.dictu-rich-text` class name.

--- a/components/rich-text/package.json
+++ b/components/rich-text/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@dictu/rich-text",
+  "version": "1.0.0",
+  "author": "Dienst ICT Uitvoering",
+  "description": "Rich Text CSS component.",
+  "license": "EUPL-1.2",
+  "keywords": [
+    "nl-design-system",
+    "css",
+    "rich-text"
+  ],
+  "repository": {
+    "type": "git+ssh",
+    "url": "git@github.com:drupalgovnl/govnl-nlds.git",
+    "directory": "components/rich-text"
+  },
+  "files": [
+    "src/",
+    "dist/",
+    "*.md"
+  ],
+  "exports": {
+    "./dist/*": "./dist/*"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "devDependencies": {
+    "@dictu/heading": "^1.0.0",
+    "@dictu/link": "^1.0.0"
+  },
+  "scripts": {
+    "build": "npx sass --pkg-importer=node --style=compressed ./src/:./dist/",
+    "watch": "npx sass --pkg-importer=node --style=compressed --watch ./src/:./dist/",
+    "clean": "rimraf ./dist/"
+  }
+}

--- a/components/rich-text/rich-text.stories.js
+++ b/components/rich-text/rich-text.stories.js
@@ -18,7 +18,7 @@ export default {
   argTypes: {
     content: {
       control: 'text',
-      description: 'De HTML inhoud van de page-container',
+      description: 'De HTML inhoud van de rich-text component',
     },
     id: {
       control: 'text',

--- a/components/rich-text/rich-text.stories.js
+++ b/components/rich-text/rich-text.stories.js
@@ -1,0 +1,75 @@
+import './dist/index.css';
+import defaultDocs from './docs/_rich-text.md?raw';
+import readme from './README.md?raw';
+
+export default {
+  args: {
+    content: `
+      <p>Paragraaf met een <a href="#">link</a>.</p>
+      <h1>Heading 1</h1>
+      <h2>Heading 2</h2>
+      <h3>Heading 3</h3>
+      <h4>Heading 4</h4>
+      <h5>Heading 5</h5>
+      <h6>Heading 6</h6>
+    `,
+    id: 'rich-text-1',
+  },
+  argTypes: {
+    content: {
+      control: 'text',
+      description: 'De HTML inhoud van de page-container',
+    },
+    id: {
+      control: 'text',
+      description: 'Container ID voor navigatie en toegankelijkheid',
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: readme,
+      },
+    },
+  },
+  render: ({ content, id }) => {
+    const container = document.createElement('div');
+    container.classList.add('dictu-rich-text');
+    container.setAttribute('id', id);
+
+    if (content) {
+      if (typeof content === 'string') {
+        // Sanitize and insert HTML
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(content, 'text/html');
+        const fragment = document.createDocumentFragment();
+
+        // Append all body children to fragment
+        Array.from(doc.body.childNodes).forEach(node => {
+          fragment.appendChild(node.cloneNode(true));
+        });
+
+        container.appendChild(fragment);
+      }
+
+      if (content instanceof HTMLElement) {
+        container.appendChild(content);
+      }
+    }
+
+    return container;
+  },
+  tags: ['autodocs'],
+  title: 'Componenten/Rich Text',
+};
+
+export const Default = {
+  args: {},
+  parameters: {
+    docs: {
+      description: {
+        story: defaultDocs,
+      },
+    },
+  },
+};

--- a/components/rich-text/src/_mixin.scss
+++ b/components/rich-text/src/_mixin.scss
@@ -1,6 +1,9 @@
 @use "pkg:@dictu/heading/src/mixin" as dictu-heading;
 @use "pkg:@dictu/link/src/mixin" as dictu-link;
 @use "pkg:@dictu/paragraph/src/mixin" as dictu-paragraph;
+@use "pkg:@dictu/design-tokens/dist/heading.css" as dictu-heading-tokens;
+@use "pkg:@dictu/design-tokens/dist/link.css" as dictu-link-tokens;
+@use "pkg:@dictu/design-tokens/dist/paragraph.css" as dictu-paragraph-tokens;
 
 /**
  * @license EUPL-1.2
@@ -9,6 +12,8 @@
 
 @mixin dictu-rich-text {
   :where(h1, h2, h3, h4, h5, h6) {
+    /* stylelint-disable-next-line scss/at-extend-no-missing-placeholder */
+    @extend .dictu-heading;
     @include dictu-heading.dictu-heading;
   }
 
@@ -37,6 +42,8 @@
   }
 
   :where(a) {
+    /* stylelint-disable-next-line scss/at-extend-no-missing-placeholder */
+    @extend .dictu-link;
     @include dictu-link.dictu-link;
   }
 
@@ -49,6 +56,8 @@
   }
 
   :where(p) {
+    /* stylelint-disable-next-line scss/at-extend-no-missing-placeholder */
+    @extend .dictu-paragraph;
     @include dictu-paragraph.dictu-paragraph;
   }
 }

--- a/components/rich-text/src/_mixin.scss
+++ b/components/rich-text/src/_mixin.scss
@@ -1,0 +1,54 @@
+@use "pkg:@dictu/heading/src/mixin" as dictu-heading;
+@use "pkg:@dictu/link/src/mixin" as dictu-link;
+@use "pkg:@dictu/paragraph/src/mixin" as dictu-paragraph;
+
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021-2025 dictu
+ */
+
+@mixin dictu-rich-text {
+  :where(h1, h2, h3, h4, h5, h6) {
+    @include dictu-heading.dictu-heading;
+  }
+
+  :where(h1) {
+    @include dictu-heading.dictu-heading--level-1;
+  }
+
+  :where(h2) {
+    @include dictu-heading.dictu-heading--level-2;
+  }
+
+  :where(h3) {
+    @include dictu-heading.dictu-heading--level-3;
+  }
+
+  :where(h4) {
+    @include dictu-heading.dictu-heading--level-4;
+  }
+
+  :where(h5) {
+    @include dictu-heading.dictu-heading--level-5;
+  }
+
+  :where(h6) {
+    @include dictu-heading.dictu-heading--level-6;
+  }
+
+  :where(a) {
+    @include dictu-link.dictu-link;
+  }
+
+  :where(a:hover) {
+    @include dictu-link.dictu-link--hover;
+  }
+
+  :where(a:active) {
+    @include dictu-link.dictu-link--active;
+  }
+
+  :where(p) {
+    @include dictu-paragraph.dictu-paragraph;
+  }
+}

--- a/components/rich-text/src/index.scss
+++ b/components/rich-text/src/index.scss
@@ -1,0 +1,5 @@
+@use "mixin" as mixin;
+
+.dictu-rich-text {
+  @include mixin.dictu-rich-text;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,22 +53,22 @@
     },
     "components/accordeon": {
       "name": "@dictu/accordeon",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.0",
       "license": "EUPL-1.2"
     },
     "components/button": {
       "name": "@dictu/button",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.0",
       "license": "EUPL-1.2"
     },
     "components/figure": {
       "name": "@dictu/figure",
-      "version": "1.0.0-alpha.1",
+      "version": "1.0.1",
       "license": "EUPL-1.2"
     },
     "components/heading": {
       "name": "@dictu/heading",
-      "version": "1.0.0-alpha.1",
+      "version": "1.0.0",
       "license": "EUPL-1.2",
       "devDependencies": {
         "@nl-design-system-candidate/heading-css": "^1.1.0"
@@ -76,22 +76,22 @@
     },
     "components/hero": {
       "name": "@dictu/hero",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.0",
       "license": "EUPL-1.2"
     },
     "components/icon": {
       "name": "@dictu/icon",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.0",
       "license": "EUPL-1.2"
     },
     "components/image": {
       "name": "@dictu/image",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.1",
       "license": "EUPL-1.2"
     },
     "components/link": {
       "name": "@dictu/link",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.0",
       "license": "EUPL-1.2",
       "devDependencies": {
         "@nl-design-system-candidate/link-css": "^2.0.0"
@@ -99,50 +99,59 @@
     },
     "components/link-list": {
       "name": "@dictu/link-list",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.1",
       "license": "EUPL-1.2"
     },
     "components/logo": {
       "name": "@dictu/logo",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.1",
       "license": "EUPL-1.2"
     },
     "components/navigation-bar": {
       "name": "@dictu/navigation-bar",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.1",
       "license": "EUPL-1.2"
     },
     "components/page-container": {
       "name": "@dictu/page-container",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.1",
       "license": "EUPL-1.2"
     },
     "components/page-footer": {
       "name": "@dictu/page-footer",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.1",
       "license": "EUPL-1.2"
     },
     "components/page-header": {
       "name": "@dictu/page-header",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.1",
       "license": "EUPL-1.2"
     },
     "components/page-section": {
       "name": "@dictu/page-section",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.1",
       "license": "EUPL-1.2"
     },
     "components/paragraph": {
       "name": "@dictu/paragraph",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.0",
       "license": "EUPL-1.2",
       "devDependencies": {
         "@nl-design-system-candidate/paragraph-css": "^2.1.0"
       }
     },
+    "components/rich-text": {
+      "name": "@dictu/rich-text",
+      "version": "1.0.0",
+      "license": "EUPL-1.2",
+      "devDependencies": {
+        "@dictu/heading": "^1.0.0",
+        "@dictu/link": "^1.0.0"
+      }
+    },
     "components/skip-link": {
       "name": "@dictu/skip-link",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.0",
       "license": "EUPL-1.2",
       "devDependencies": {
         "@nl-design-system-candidate/skip-link-css": "^1.0.2"
@@ -150,7 +159,7 @@
     },
     "components/timeline": {
       "name": "@dictu/timeline",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.0",
       "license": "EUPL-1.2"
     },
     "node_modules/@adobe/css-tools": {
@@ -1016,6 +1025,10 @@
     },
     "node_modules/@dictu/paragraph": {
       "resolved": "components/paragraph",
+      "link": true
+    },
+    "node_modules/@dictu/rich-text": {
+      "resolved": "components/rich-text",
       "link": true
     },
     "node_modules/@dictu/skip-link": {
@@ -11913,12 +11926,12 @@
     },
     "proprietary/assets": {
       "name": "@dictu/assets",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.1",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "proprietary/design-tokens": {
       "name": "@dictu/design-tokens",
-      "version": "1.0.0-alpha.1",
+      "version": "1.0.1",
       "license": "SEE LICENSE IN LICENSE.md",
       "devDependencies": {
         "@tokens-studio/sd-transforms": "1.2.3",

--- a/proprietary/design-tokens/style-dictionary-build.mjs
+++ b/proprietary/design-tokens/style-dictionary-build.mjs
@@ -58,7 +58,7 @@ const components = new StyleDictionary({
           format: 'css/variables',
           filter: token => token.filePath === file,
           options: {
-            selector: `.dictu-theme`,
+            selector: `.dictu-${path.parse(file).name.toLowerCase().replace('.tokens', '')}`,
             outputReferences: true,
           },
         })),

--- a/proprietary/design-tokens/style-dictionary-build.mjs
+++ b/proprietary/design-tokens/style-dictionary-build.mjs
@@ -1,6 +1,6 @@
+import { register } from '@tokens-studio/sd-transforms';
 import { globSync } from 'glob';
 import path from 'path';
-import { register } from '@tokens-studio/sd-transforms';
 import StyleDictionary from 'style-dictionary';
 
 // will register them on StyleDictionary object
@@ -58,7 +58,7 @@ const components = new StyleDictionary({
           format: 'css/variables',
           filter: token => token.filePath === file,
           options: {
-            selector: `.dictu-${path.parse(file).name.toLowerCase().replace('.tokens', '')}`,
+            selector: `.dictu-theme`,
             outputReferences: true,
           },
         })),


### PR DESCRIPTION
In onze implementatie in Drupal lopen we er tegenaan dat het lastig is om CSS klasses toe te voegen aan opgemaakte tekst die door een redacteur wordt ingevoerd in de wysiwyg editor. 

Het Rich Text component zorgt ervoor dat standaard html elementen binnen dit component worden opgemaakt op basis van de componenten in het design system. 

Dit component heeft nu ondersteuning voor paragrafen, kopteksten en links. In de toekomst kunnen hier eventueel extra componenten aan toegevoegd worden, zoals lijsten, tabellen en citaten. 