### PR TITLE
chore(design-tokens): add changeset for timeline tokens

### DIFF
--- a/.changeset/design-tokens-timeline-tokens.md
+++ b/.changeset/design-tokens-timeline-tokens.md
@@ -1,0 +1,5 @@
+---
+"@dictu/design-tokens": minor
+---
+
+Add timeline design tokens for the connector icon-center and sub-icon-center, heading text-align, content align-items, and button justify-content, so the timeline component relies on tokens instead of hardcoded values and mixin arguments.


### PR DESCRIPTION
## Context

PR #335 added new timeline design tokens to `@dictu/design-tokens` (connector `icon-center`/`sub-icon-center`, `heading.text-align`, `content.align-items`, `button.justify-content`), but only shipped a changeset for `@dictu/timeline`. As a result the release bot bumped `@dictu/timeline` while `@dictu/design-tokens` stayed at 2.15.0 — so the new tokens are in `main` but unreleased.

## Change

Adds the missing changeset bumping `@dictu/design-tokens` as a **minor** release (matching the repo convention for added tokens), so the next release publishes the new timeline tokens.

No source changes — changeset only.