### PR TITLE
fix: keep card icon color in focus state

### DIFF
--- a/.changeset/card-focus-visible-icon-color.md
+++ b/.changeset/card-focus-visible-icon-color.md
@@ -1,0 +1,5 @@
+---
+"@dictu/card": patch
+---
+
+Fix the card icon color during keyboard focus of a full-card link, so it matches the focused link text for both default and accent cards.

--- a/components/card/src/_mixin.scss
+++ b/components/card/src/_mixin.scss
@@ -46,6 +46,7 @@
   border-color: var(--govnl-card-default-focus-border-color);
   color: var(--govnl-card-default-focus-color);
 
+  --govnl-card-default-icon-color: var(--govnl-card-default-focus-color);
   --govnl-card-default-metadata-subheading-color: var(--govnl-card-default-focus-color);
   --govnl-card-default-metadata-footer-color: var(--govnl-card-default-focus-color);
 }
@@ -81,6 +82,7 @@
   --govnl-card-accent-focus-border-color: var(--govnl-card-accent-focus-border-color);
   --govnl-card-accent-color: var(--govnl-card-accent-focus-color);
   --govnl-card-accent-heading-color: var(--govnl-card-accent-focus-color);
+  --govnl-card-accent-icon-color: var(--govnl-card-accent-focus-color);
   --govnl-card-accent-paragraph-color: var(--govnl-card-accent-focus-color);
   --govnl-card-accent-metadata-footer-color: var(--govnl-card-accent-focus-color);
   --govnl-card-accent-metadata-subheading-color: var(--govnl-card-accent-focus-color);


### PR DESCRIPTION
## What changed

- Update the default and accent full-card focus states to override the icon color token.
- Add a patch changeset for the card package.

## Why

The card icon now has an explicit variant color token. The full-card focus styles updated the text colors but did not override that icon token, causing the icon and focused link text to use different colors.

## Impact

During keyboard focus, the icon now matches the link text for both default and accent full-card links.

## Validation

- TypeScript typecheck
- Bundle size checks
- Stylelint and Prettier pre-commit checks
- Card Sass build
- Manual verification in Storybook for default and accent variants

## Notes

No automated browser test was added.